### PR TITLE
Add test automation for PostgreSQL 13

### DIFF
--- a/.github/workflows/test-pg13.yaml
+++ b/.github/workflows/test-pg13.yaml
@@ -1,0 +1,65 @@
+name: PostgreSQL 13 regression tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main 
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Append /usr/local/pgsql/bin to PATH
+      run:  echo "/usr/local/pgsql/bin" >> $GITHUB_PATH
+    - name: Uninstall Ubuntu's postgresql installation
+      run:  sudo apt purge -y postgresql-14 postgresql-client-14 postgresql-client-common postgresql-common libpq-dev
+    - name: Do an apt-get update
+      run:  sudo apt-get update
+    - name: Install build dependencies for postgresql
+      run:  sudo apt-get install -y build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev libssl-dev libxml2-utils xsltproc ccache libperl-dev
+    - name: Install CPAN dependencies
+      run:  sudo cpan -i "IPC::Run"
+    - name: download postgresql
+      run:  >
+        cd ~ &&
+        curl -O https://ftp.postgresql.org/pub/source/v13.9/postgresql-13.9.tar.gz &&
+        curl -O https://ftp.postgresql.org/pub/source/v13.9/postgresql-13.9.tar.gz.sha256
+    - name: verify postgresql
+      run:  >
+        cd ~ &&
+        sha256sum --check postgresql-13.9.tar.gz.sha256
+    - name: build postgresql
+      run:  >
+        cd ~ &&
+        tar xzf postgresql-13.9.tar.gz &&
+        cd postgresql-13.9 &&
+        ./configure --enable-tap-tests --enable-cassert --enable-debug --with-openssl --with-perl &&
+        make &&
+        sudo PATH=$PATH make install &&
+        cd contrib && make && sudo PATH=$PATH make install &&
+        cd ../src/test/perl && sudo PATH=$PATH make install
+    - name: initialize postgresql database
+      run:  >
+        mkdir ~/data &&
+        chmod -R 700 ~/data &&
+        initdb -D ~/data &&
+        pg_ctl -D ~/data start
+    - uses: actions/checkout@v3
+    - name: Compile pg_tle extension
+      run:  make
+    - name: Install pg_tle extension
+      run:  sudo PATH=$PATH make install
+    - name: Add pg_tle to shared_preload_libraries
+      run:  >
+        echo "shared_preload_libraries = 'pg_tle'" >> ~/data/postgresql.conf
+    - name: Restart postgresql
+      run:  pg_ctl -D ~/data restart
+    - name: Run pg_tle regression tests
+      id:   regression-tests
+      run:  PERL5LIB="${HOME}/postgresql-13.9/src/test/perl:${PERL5LIB}" make installcheck
+    - name: Print regression.diffs if regression tests failed
+      if:   failure() && steps.regression-tests.outcome != 'success'
+      run:  cat regression.diffs

--- a/src/guc-file.l
+++ b/src/guc-file.l
@@ -20,7 +20,9 @@
 #include "miscadmin.h"
 #include "storage/fd.h"
 #include "utils/guc.h"
-
+#if PG_VERSION_NUM < 140000
+#include "utils/memutils.h"
+#endif
 
 /*
  * flex emits a yy_fatal_error() function that it calls in response to


### PR DESCRIPTION
This adds an automation workflow to test `pg_tle` for PostgreSQL 13.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
